### PR TITLE
Add the possibility to edit token_endpoint and authorization_endpoint

### DIFF
--- a/lib/omniauth/strategies/azure_active_directory_b2c/policy.rb
+++ b/lib/omniauth/strategies/azure_active_directory_b2c/policy.rb
@@ -4,9 +4,9 @@ module OmniAuth
       class Policy
         include AzureActiveDirectoryB2C::PolicyOptions
 
-        attr_reader :application_identifier, :application_secret, :issuer, :tenant_name, :policy_name, :jwk_signing_algorithm, :jwk_signing_keys
+        attr_reader :application_identifier, :application_secret, :issuer, :tenant_name, :policy_name, :jwk_signing_algorithm, :jwk_signing_keys, :token_endpoint, :authorization_endpoint
 
-        def initialize(application_identifier:, application_secret:, issuer:, tenant_name:, policy_name:, jwk_signing_algorithm:, jwk_signing_keys:, scope: nil)
+        def initialize(application_identifier:, application_secret:, issuer:, tenant_name:, policy_name:, jwk_signing_algorithm:, jwk_signing_keys:, token_endpoint: nil, authorization_endpoint: nil, scope: nil)
           @application_identifier = application_identifier
           @application_secret = application_secret
           @issuer = issuer
@@ -15,6 +15,8 @@ module OmniAuth
           @jwk_signing_algorithm = jwk_signing_algorithm
           @jwk_signing_keys = jwk_signing_keys
           @scope = *scope
+          @token_endpoint = token_endpoint
+          @authorization_endpoint = authorization_endpoint
         end
 
         def scope

--- a/lib/omniauth/strategies/azure_active_directory_b2c/policy_options.rb
+++ b/lib/omniauth/strategies/azure_active_directory_b2c/policy_options.rb
@@ -41,11 +41,11 @@ module OmniAuth
         end
 
         def policy_authorization_endpoint
-          '%s/oauth2/v2.0/authorize' % host_name
+          @authorization_endpoint || '%s/oauth2/v2.0/authorize' % host_name
         end
 
         def policy_token_endpoint
-          '%s/oauth2/v2.0/token' % host_name
+          @token_endpoint || '%s/oauth2/v2.0/token' % host_name
         end
 
         def policy_jwks_uri


### PR DESCRIPTION
This adds a possibility to edit token_endpoint and authorization_endpoint, as sometimes openidconnect on b2c azure can be configured so it doesn't follow the default scheme.