### PR TITLE
Set redirect URLs to b2clogin.com

### DIFF
--- a/lib/omniauth/strategies/azure_active_directory_b2c/policy_options.rb
+++ b/lib/omniauth/strategies/azure_active_directory_b2c/policy_options.rb
@@ -36,8 +36,12 @@ module OmniAuth
           raise MissingOptionError, '`policy_name` not defined'
         end
 
+        def tenant_identifier
+          @tenant_identifier ||= tenant_name.gsub('.onmicrosoft.com', '')
+        end
+
         def policy_host_name
-          'https://login.microsoftonline.com/te/%s/%s' % [tenant_name, policy_name]
+          'https://%s.b2clogin.com/%s/%s' % [tenant_identifier, tenant_name, policy_name]
         end
 
         def policy_authorization_endpoint


### PR DESCRIPTION
URLs of the form `login.microsoft.com` are being redirected in favour of the `b2clogin.com`.

As they will no longer work after the 4th of December, update the library so take into account the changes.

More details can be found [here](https://docs.microsoft.com/en-us/azure/active-directory-b2c/b2clogin#change-identity-provider-redirect-urls).