### PR TITLE
Bump openid_connect to 2.2

### DIFF
--- a/omniauth-azure_active_directory_b2c.gemspec
+++ b/omniauth-azure_active_directory_b2c.gemspec
@@ -28,5 +28,5 @@ Gem::Specification.new do |spec|
     ]
 
   spec.add_dependency 'omniauth', '~> 1.3'
-  spec.add_dependency 'openid_connect', '~> 1.1'
+  spec.add_dependency 'openid_connect', '~> 2.2'
 end


### PR DESCRIPTION
To switch from gitlab-omniauth-openid-connect to omniauth_openid_connect, we need to support openid_connect 2.2, follows https://github.com/omniauth/omniauth_openid_connect/blob/master/omniauth_openid_connect.gemspec#L31

This should also allow us to get rid of our `httpclient` fork in some future.